### PR TITLE
Fix package count for openSUSE. 3.7

### DIFF
--- a/disfetch
+++ b/disfetch
@@ -259,7 +259,7 @@ PACKAGES="$(
         nixos*) packages_nix;;
         slack*) packages_slack;;
         void*) packages_xbps;;
-        opensuse*) packages_opensuse;;
+        opensuse*) packages_rpm;;
     esac
 )"
 

--- a/disfetch
+++ b/disfetch
@@ -238,7 +238,6 @@ packages_haiku() { pkgman search -ia  2>/dev/null |
 packages_nix() { nix-store -q --requisites ~/.nix-profile 2>/dev/null | wc -l; }
 packages_pacman() { pacman -Qq 2>/dev/null | wc -l; }
 packages_rpm() { rpm -qa 2>/dev/null | wc -l; }
-packages_zypper() { zypper se --installed-only 2>/dev/null | wc -l; }
 packages_slack() { find /var/log/packages -mindepth 1 -maxdepth 1 2>/dev/null |
     wc -l; }
 packages_xbps() { xbps-query -l 2>/dev/null | wc -l; }
@@ -253,13 +252,12 @@ PACKAGES="$(
             packages_dpkg;;
         arc*|artix*|endeavour*|manjaro*|garuda*|msys2*|parabola*)
             packages_pacman;;
-        fedora*|qubes*|cent*|redhat*) packages_rpm;;
+        fedora*|qubes*|cent*|redhat*|opensuse*) packages_rpm;;
         gentoo*) packages_emerge;;
         haiku*) packages_haiku;;
         nixos*) packages_nix;;
         slack*) packages_slack;;
         void*) packages_xbps;;
-        opensuse*) packages_rpm;;
     esac
 )"
 


### PR DESCRIPTION
For some reason, for the package count for OS "opensuse" is set to "packages_opensuse", but that function does not exist, resulting in the error `./disfetch: 262: packages_opensuse: not found` and no package count info on the fetch.

The existing functions that are compatible are "packages_rpm" and "packages_zypper". I used [hyperfine](https://github.com/sharkdp/hyperfine) to benchmark both, and using `rpm` directly is faster than using `zypper`. 
![image](https://user-images.githubusercontent.com/62779748/226142936-7c12c4a0-f6ec-4984-a0af-e3feafd79b19.png)


 This simple pull request sets the package count grabbing method of OS "opensuse" to "packages_rpm".